### PR TITLE
Add an option to allow configuring the target window of goto-item

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -371,6 +371,11 @@ used."
   "Extra arguments to pass to rg."
   :type '(repeat string))
 
+(defcustom magit-todos-window-setup 'same
+  "Window to show the actual location of a todo."
+  :type '(choice (const :tag "Same window" same)
+                 (const :tag "Other window" other)))
+
 ;;;; Structs
 
 (cl-defstruct magit-todos-item
@@ -397,13 +402,16 @@ used."
   (pcase-let* ((item (magit-current-section))
                ((eieio value) item)
                ((cl-struct magit-todos-item filename position line column) value))
-    (switch-to-buffer (or (find-buffer-visiting filename)
-                          (find-file-noselect filename)))
-    (if position
-        (goto-char position)
-      (goto-char (point-min))
-      (forward-line (1- line))
-      (forward-char column))))
+    (with-current-buffer (or (find-buffer-visiting filename)
+                             (find-file-noselect filename))
+      (cl-case magit-todos-window-setup
+        (other (pop-to-buffer (current-buffer)))
+        (otherwise (pop-to-buffer-same-window (current-buffer))))
+      (if position
+          (goto-char position)
+        (goto-char (point-min))
+        (forward-line (1- line))
+        (forward-char column)))))
 
 ;;;; Functions
 


### PR DESCRIPTION
If you press `RET` on a commit in a `magit-status` buffer, magit shows diffs in other window and focus the window. This seems to be a common behavior in `magit-status`. 

On the other hand, magit-todos shows the actual location of a todo in the same window. 

I think this is inconsistent, so I've added an option to configure the target window. The default option is the same window for now so that it won't distract existing magit-todos users, but I personally prefer other window. 

Also, I think `pop-to-buffer-same-window`/`pop-to-buffer` are better than `switch-to-buffer`/`switch-to-buffer-other-window`, because they are based on `display-buffer`. `display-buffer` allows you to customize its behaviours through `display-buffer-alist` variable. [shackle](https://github.com/wasamasa/shackle) leverages this feature.
