### PR TITLE
package-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.elpa/
+/.elpa.test/
+/emacs-travis.mk
+/emake.el
+/emake.mk
+*.elc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+sudo: required
+dist: trusty
+cache:
+- directories:
+  - "$HOME/emacs"
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: EMACS_VERSION=25.1
+  - env: EMACS_VERSION=snapshot
+env:
+  matrix:
+  - EMACS_VERSION=25.1
+  - EMACS_VERSION=25.2
+  - EMACS_VERSION=25.3
+  - EMACS_VERSION=26.1
+  - EMACS_VERSION=snapshot
+before_install:
+- make emake.mk
+- make setup
+install:
+- make .elpa
+script:
+- make test                     # test uncompiled
+- make compile                  # test compilation
+- make test                     # test compiled

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# EMACS_VERSION should be set in your ~/.profile on your development machine
+EMAKE_SHA1            := 4208a5e4e68c0e13ecd57195209bdeaf5959395f
+PACKAGE_BASENAME      := magit-todos
+
+# override defaults
+PACKAGE_ARCHIVES      := gnu melpa
+# PACKAGE_TESTS         := test-sample.el # normally, EMake would discover these in the test/ directory
+PACKAGE_TEST_DEPS     := dash
+PACKAGE_TEST_ARCHIVES := gnu melpa
+
+### Bootstrap and convenience targets
+
+.DEFAULT_GOAL: help
+
+# test: test-ert test-buttercup   ## run tests
+test:
+lint: lint-package-lint lint-checkdoc ## run lints
+
+emake.mk:                       ## download the emake Makefile
+	curl -O 'https://raw.githubusercontent.com/vermiculus/emake.el/$(EMAKE_SHA1)/emake.mk'
+
+include emake.mk

--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 <a href=https://alphapapa.github.io/dont-tread-on-emacs/><img src="dont-tread-on-emacs-150.png" align="right"></a>
 #+END_HTML
 
-* magit-todos
+* magit-todos [[https://travis-ci.org/alphapapa/magit-todos.svg?branch=master]]
 
   [[https://melpa.org/#/magit-todos][file:https://melpa.org/packages/magit-todos-badge.svg]] [[https://stable.melpa.org/#/magit-todos][file:https://stable.melpa.org/packages/magit-todos-badge.svg]]
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -346,8 +346,6 @@ used."
                  (const :tag "After unstaged files" unstaged)
                  (symbol :tag "After selected section")))
 
-;; TODO: Split each string in these extra args, because users won't know to insert them separately.
-
 (defcustom magit-todos-ag-args nil
   "Extra arguments to pass to ag."
   :type '(repeat string))
@@ -755,7 +753,9 @@ This is a copy of `async-start-process' that does not override
          (command (list "--ackmate" "--depth" depth
                         magit-todos-search-regexp directory)))
     (when magit-todos-ag-args
-      (setq command (append magit-todos-ag-args command)))
+      (setq command (append (-flatten (--map (s-split (rx (1+ space)) 'omit-nulls)
+                                             magit-todos-ag-args))
+                            command)))
     (push "ag" command)
     (when magit-todos-nice
       (setq command (append (list "nice" "-n5") command)))
@@ -793,7 +793,9 @@ This is a copy of `async-start-process' that does not override
          (command (list "--column" "--maxdepth" depth
                         magit-todos-search-regexp directory)))
     (when magit-todos-rg-args
-      (setq command (append magit-todos-rg-args command)))
+      (setq command (append (-flatten (--map (s-split (rx (1+ space)) 'omit-nulls)
+                                             magit-todos-rg-args))
+                            command)))
     (push "rg" command)
     (when magit-todos-nice
       (setq command (append (list "nice" "-n5") command)))
@@ -833,7 +835,9 @@ This is a copy of `async-start-process' that does not override
                         "--perl-regexp" "-e" magit-todos-search-regexp
                         "--" directory)))
     (when magit-todos-git-grep-args
-      (setq command (append magit-todos-git-grep-args command)))
+      (setq command (append (-flatten (--map (s-split (rx (1+ space)) 'omit-nulls)
+                                             magit-todos-git-grep-args))
+                            command)))
     (push magit-git-executable command)
     (when magit-todos-nice
       (setq command (append (list "nice" "-n5") command)))

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -105,8 +105,6 @@ This should be set automatically by customizing
 This should be set automatically by customizing
 `magit-todos-keywords'.")
 
-;; TODO: Remove extra search regexp var, no longer needed without internal scanner.
-
 (defvar magit-todos-git-grep-result-regexp nil
   "Regular expression for git-grep results.
 This should be set automatically by customizing

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -503,7 +503,7 @@ sections."
   ;; variable gets filled with extra entries with incorrect visibility states, and then `alist-get'
   ;; gets the wrong value.  Need to see if that happens when magit-todos-mode is off.
 
-  ;; FIXME: `magit-insert-section' seems to bind `magit-section-visibility-cache' to nil, so setting
+  ;; NOTE: `magit-insert-section' seems to bind `magit-section-visibility-cache' to nil, so setting
   ;; visibility within calls to it probably won't work as intended.
   (declare (indent defun))
   (let* ((indent (s-repeat depth " "))


### PR DESCRIPTION
As suggested by the MELPA guideline, [package-lint](https://github.com/purcell/package-lint/) and byte-compile helps you identify some errors. It sometimes find it's too noisy even for non-fatal problems, but it indeed helps to some extent.

A recent package named [emake](https://github.com/vermiculus/emake.el) lets you easily set up a test suite with package-lint, checkdoc, and emake/buttercup tests. I've experimentally added a test suite based on [this example](https://github.com/vermiculus/emake.el-example). At present, [byte-compile fails due to some errors](https://travis-ci.org/akirak/magit-todos/builds/397657299). 

If you'd find this useful, you can merge this branch.