### PR TITLE
Use cl-lib prefixed functions consistently

### DIFF
--- a/README.org
+++ b/README.org
@@ -100,6 +100,9 @@ Run =magit-todos-mode=, then open a Magit status buffer.
 +  Remove dependency on ~a~.
 +  Remove dependency on =anaphora=.
 
+*Fixes*
++  Add missing ~cl-~ prefix.  Thanks to [[https://github.com/jellelicht][Jelle Licht]].
+
 *** 1.0.4
 
 *Fixes*

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -695,7 +695,7 @@ advance to the next line."
   (when magit-todos-ignore-case
     (setq keyword (upcase keyword)))
   (let ((face (assoc-default keyword hl-todo-keyword-faces #'string=)))
-    (typecase face
+    (cl-typecase face
       (string (list :inherit 'hl-todo :foreground face))
       (t face))))
 


### PR DESCRIPTION
typecase might not be defined properly when magit-todos is loaded, leading to magit-todos--keyword-face being compiled in a way that sees the `(typecase (string ...) ...)` as a function call rather than a macro invocation, which is a Bad Thing.