### PR TITLE
Kill grep buffers after their results are parsed

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -484,11 +484,13 @@ Chooses automatically in order defined in `magit-todos-scanners'."
   ;; SOMEDAY: Perhaps move process buffer parsing into separate function.
   (with-current-buffer (process-buffer process)
     (goto-char (point-min))
-    (magit-todos--insert-items magit-status-buffer
-      (cl-loop for item = (magit-todos--line-item results-regexp)
-               while item
-               collect item
-               do (forward-line 1)))))
+    (prog1
+        (magit-todos--insert-items magit-status-buffer
+          (cl-loop for item = (magit-todos--line-item results-regexp)
+                   while item
+                   collect item
+                   do (forward-line 1)))
+      (kill-buffer (current-buffer)))))
 
 (defun magit-todos--delete-section (condition)
   "Delete the section specified by CONDITION from the Magit status buffer.


### PR DESCRIPTION
I was getting a bunch of rg buffers hanging around: this seems to be the appropriate fix.

(P.S. Somewhat related, you should start the temp buffer names with ` *` rather than just `*`, so that they will automatically be hidden in `ibuffer` etc.)