### PR TITLE
Fix: inconsistent section header faces

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,6 +117,9 @@ Activate =magit-todos-mode=.  Then open a Magit status buffer, or run ~magit-tod
 +  Optionally group and sort by item suffixes (e.g. handy when suffixes contain usernames).
 +  Bind @@html:<kbd>@@RET@@html:</kbd>@@ on top-level =TODOs= section heading to ~magit-todos-list~ command.
 
+*Fixed*
++  Don't fontify section item counts.  (Thanks to [[https://github.com/m-cat][Marcin Swieczkowski]].)
+
 *Removed*
 + Option ~magit-todos-require-colon~, replaced by ~magit-todos-keyword-suffix~.
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -614,10 +614,13 @@ This function should be called from inside a ‘magit-status’ buffer."
                   ;; Manual updates: Insert section to remind user
                   (let ((magit-insert-section--parent magit-root-section))
                     (magit-insert-section (todos)
-                      (magit-insert-heading (concat "TODOs (0)" reminder)))
+                      (magit-insert-heading (concat (propertize "TODOs" 'face 'magit-section-heading)
+                                                    " (0)" reminder)))
                     (insert "\n")))
               (let ((section (magit-todos--insert-groups :type 'todos
-                               :heading (format "TODOs (%s)%s" num-items reminder)
+                               :heading (format "%s (%s)%s"
+                                                (propertize "TODOs" 'face 'magit-section-heading)
+                                                num-items reminder)
                                :group-fns group-fns
                                :items items
                                :depth 0)))


### PR DESCRIPTION
Fixes #64 

Also did some cleanup because it seemed like some functionality was duplicated in the `(if (not items) (unless magit-todos-update` case, which should all be caught by `(cond ((or items (not magit-todos-update))` and handled in the same place.