### PR TITLE
Include newline in section body

### DIFF
--- a/README.org
+++ b/README.org
@@ -111,7 +111,8 @@ Activate =magit-todos-mode=.  Then open a Magit status buffer, or run ~magit-tod
 
 *** 1.3-pre
 
-Nothing new yet.
+*Internal*
++  Put newline in section headings.  (#68.  Thanks to [[https://github.com/vermiculus][Sean Allred]].)
 
 *** 1.2
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -616,8 +616,7 @@ This function should be called from inside a ‘magit-status’ buffer."
                   (let ((magit-insert-section--parent magit-root-section))
                     (magit-insert-section (todos)
                       (magit-insert-heading (concat (propertize "TODOs" 'face 'magit-section-heading)
-                                                    " (0)" reminder)))
-                    (insert "\n")))
+                                                    " (0)" reminder "\n")))))
               (let ((section (magit-todos--insert-groups :type 'todos
                                :heading (format "%s (%s)%s"
                                                 (propertize "TODOs" 'face 'magit-section-heading)
@@ -728,8 +727,7 @@ sections."
                                                            item))
                                           (truncate-string-to-width it width))))
                         (magit-insert-section (todos-item item)
-                          (insert string))
-                        (insert "\n"))))))
+                          (insert string "\n")))))))
     (magit-todos--set-visibility :depth depth :num-items (length items) :section section)
     ;; Don't forget to return the section!
     section))


### PR DESCRIPTION
Released sections include the newline within the section body/header.