### PR TITLE
Fix: Prevent the message if there is the desired binding

### DIFF
--- a/README.org
+++ b/README.org
@@ -119,6 +119,7 @@ Activate =magit-todos-mode=.  Then open a Magit status buffer, or run ~magit-tod
 
 *Fixed*
 +  Properly unbind key when mode is disabled. ([[https://github.com/alphapapa/magit-todos/pull/74][#74]].  Thanks to [[https://github.com/akirak][Akira Komamura]].)
++  Don't show message when key is already bound correctly.  ([[https://github.com/alphapapa/magit-todos/pull/75][#75]].  Thanks to [[https://github.com/akirak][Akira Komamura]].)
 
 *** 1.1.7
 

--- a/README.org
+++ b/README.org
@@ -98,6 +98,28 @@ Activate =magit-todos-mode=.  Then open a Magit status buffer, or run ~magit-tod
 :TOC:      0
 :END:
 
+*** 1.2-pre
+
+*Added*
++  Allow ~magit-todos-list~ to work outside git repos.
++  Option ~magit-todos-keyword-suffix~ replaces ~magit-todos-require-colon~, allowing for common and custom suffixes after item keywords (e.g. to match items like =TODO(user):=).  (Fixes [[https://github.com/alphapapa/magit-todos/issues/56][#56]].  Thanks to [[https://github.com/thiderman][Lowe Thiderman]] for suggesting.)
++  Optionally group and sort by item suffixes (e.g. handy when suffixes contain usernames).
++  Bind @@html:<kbd>@@RET@@html:</kbd>@@ on top-level =TODOs= section heading to ~magit-todos-list~ command.
+
+*Fixed*
++  Don't fontify section item counts.  (Thanks to [[https://github.com/m-cat][Marcin Swieczkowski]].)
+
+*Worked Around*
++  Issue in =async= regarding deleted buffers/processes.  This is not an ideal solution, but it solves the problem for now.
+
+*Removed*
++ Option ~magit-todos-require-colon~, replaced by ~magit-todos-keyword-suffix~.
+
+*** 1.1.8
+
+*Fixed*
++  Properly unbind key when mode is disabled. ([[https://github.com/alphapapa/magit-todos/pull/74][#74]].  Thanks to [[https://github.com/akirak][Akira Komamura]].)
+
 *** 1.1.7
 
 *Fixed*

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -330,9 +330,10 @@ used."
   :global t
   (if magit-todos-mode
       (progn
-        (if (lookup-key magit-status-mode-map "jT")
-            (message "magit-todos: Not overriding bind of \"jT\" in `magit-status-mode-map'.")
-          (define-key magit-status-mode-map "jT" #'magit-todos-jump-to-todos))
+        (pcase (lookup-key magit-status-mode-map "jT")
+          (nil (define-key magit-status-mode-map "jT" #'magit-todos-jump-to-todos))
+          ('magit-todos-jump-to-todos nil)
+          (_ (message "magit-todos: Not overriding bind of \"jT\" in `magit-status-mode-map'.")))
         (magit-add-section-hook 'magit-status-sections-hook
                                 #'magit-todos--insert-todos
                                 'magit-insert-staged-changes

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/magit-todos
-;; Version: 1.1.7
+;; Version: 1.1.8-pre
 ;; Package-Requires: ((emacs "25.2") (async "1.9.2") (dash "2.13.0") (f "0.17.2") (hl-todo "1.9.0") (magit "2.13.0") (pcre2el "1.8") (s "1.12.0"))
 ;; Keywords: magit, vc
 
@@ -339,7 +339,7 @@ used."
                                 'append)
         (add-hook 'magit-status-mode-hook #'magit-todos--add-to-status-buffer-kill-hook 'append))
     ;; Disable mode
-    (when (equal (lookup-key magit-status-mode-map "jT") #'magit-jump-to-todos)
+    (when (equal (lookup-key magit-status-mode-map "jT") #'magit-todos-jump-to-todos)
       (define-key magit-status-mode-map "jT" nil))
     (remove-hook 'magit-status-sections-hook #'magit-todos--insert-todos)
     (remove-hook 'magit-status-mode-hook #'magit-todos--add-to-status-buffer-kill-hook)))


### PR DESCRIPTION
This prevents the following message if the key is bound to the exactly same command:

> "magit-todos: Not overriding bind of \"jT\" in `magit-status-mode-map'."

The above message was shown every time my Emacs started. which is a bit undesired behavior. Now it seems to have been fixed.