### PR TITLE
Memoize rxt-elisp-to-pcre

### DIFF
--- a/README.org
+++ b/README.org
@@ -65,13 +65,14 @@ If you installed from MELPA, you're done!
 
 Install these required packages:
 
--  =async=
--  =dash=
--  =f=
--  =hl-todo=
--  =magit=
--  =pcre2el=
--  =s=
+- =async=
+- =dash=
+- =f=
+- =hl-todo=
+- =magit=
+- =pcre2el=
+- =s=
+- =memoize=
 
 Then put this file in your =load-path=, and put this in your init file:
 


### PR DESCRIPTION
Aside from starting the process, it's the slowest measurable part of every
scanner. We could possibly memoize the rx-to-string as well based on the
keywords and the magit-todos-keyword-suffix. It does show up on profiles after
rxt-elisp-to-pcre is memoized, but it only accounts for maybe 4ms during the
refresh.

This does add a new dependency, memoize.