### PR TITLE
Fix RET not jumping to item on point

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -129,7 +129,7 @@ magit-status buffer.")
 
 (defvar magit-todos-item-section-map
   (let ((map (copy-keymap magit-todos-section-map)))
-    (define-key map [remap magit-visit-thing] #'magit-todos-jump-to-item)
+    (define-key map [remap magit-todos-list] #'magit-todos-jump-to-item)
     (define-key map [remap magit-diff-show-or-scroll-up] #'magit-todos-peek-at-item)
     map)
   "Keymap for `magit-todos' individual to-do item sections.


### PR DESCRIPTION
It seems that this behavior broke on https://github.com/alphapapa/magit-todos/commit/a51128fb86e81eda4ea0976b9df138123f3fbf8f?