### PR TITLE
Prevent face-bleedover of sections into indent whitespace.

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -780,7 +780,7 @@ sections."
   ;; NOTE: `magit-insert-section' seems to bind `magit-section-visibility-cache' to nil, so setting
   ;; visibility within calls to it probably won't work as intended.
   (declare (indent defun))
-  (let* ((indent (s-repeat (* 2 depth) " "))
+  (let* ((indent (propertize (s-repeat (* 2 depth) " ") 'face nil))
          (heading (concat indent heading))
          (magit-insert-section--parent (if (= 0 depth)
                                            magit-root-section
@@ -842,7 +842,7 @@ sections."
   ;; NOTE: `magit-insert-section' seems to bind `magit-section-visibility-cache' to nil, so setting
   ;; visibility within calls to it probably won't work as intended.
   (declare (indent defun))
-  (let* ((indent (s-repeat (* 2 depth) " "))
+  (let* ((indent (propertize (s-repeat (* 2 depth) " ") 'face nil))
          (magit-insert-section--parent (if (= 0 depth)
                                            magit-root-section
                                          magit-insert-section--parent))


### PR DESCRIPTION
Forcing the face to nil will prevent face properties like `:underline` from bleeding over into the indent whitespace.

Before:
![before](https://user-images.githubusercontent.com/5951157/93014454-7f2ea000-f5b1-11ea-8adb-0eb75e45d792.png)

After:
![after](https://user-images.githubusercontent.com/5951157/93014461-85248100-f5b1-11ea-99d8-3c81a4c30aac.png)
