### PR TITLE
Add magit-todos-filename-modifier customization option

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -359,6 +359,13 @@ from the \"topic2\" branch, this option could be set to
   "Show submodule to-do list."
   :type 'boolean)
 
+(defcustom magit-todos-trim-filename-filter nil
+  "Function through which file names are filtered..
+Function takes relative file path as an argument and must return string."
+  :type '(choice (const :tag "No filter" nil)
+                 (function-item :tag "Function-only" f-filename)
+                 (function :tag "Custom function")))
+
 ;;;; Commands
 
 ;;;###autoload
@@ -851,6 +858,8 @@ sections."
                       (let* ((filename (propertize (magit-todos-item-filename item) 'face 'magit-filename))
                              (string (--> (concat indent
                                                   (when magit-todos-show-filenames
+                                                    (when magit-todos-trim-filename-filter
+                                                      (setf filename (funcall magit-todos-trim-filename-filter filename)))
                                                     (concat filename " "))
                                                   (funcall (if (s-suffix? ".org" filename)
                                                                #'magit-todos--format-org


### PR DESCRIPTION
Apply function stored in magit-todos-filename-modifier to the filenames.
Closes #105

For example, this is the default view with full path:
![2020-10-27_20-48](https://user-images.githubusercontent.com/26824900/97341446-203d9580-1896-11eb-8c5e-c1574d547f2f.png)

And with function `f-filename` applied:
![2020-10-27_20-49](https://user-images.githubusercontent.com/26824900/97341540-3ea39100-1896-11eb-9ed8-99c7256f6dc2.png)
