### PR TITLE
Add magit-todos-show-submodule-notes customization option

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -359,6 +359,10 @@ from the \"topic2\" branch, this option could be set to
 \"topic\"."
   :type 'string)
 
+(defcustom magit-todos-show-submodule-notes t
+  "Show submodule to-do list."
+  :type 'boolean)
+
 ;;;; Commands
 
 ;;;###autoload
@@ -1272,6 +1276,9 @@ When SYNC is non-nil, match items are returned."
                  (when magit-todos-exclude-globs
                    (--map (list "--glob" (concat "!" it))
                           magit-todos-exclude-globs))
+                 (unless magit-todos-show-submodule-notes
+                   (--map (list "--glob" (concat "!" it))
+                          (magit-list-module-paths)))
                  extra-args search-regexp-pcre directory))
 
 (magit-todos-defscanner "git grep"
@@ -1287,7 +1294,10 @@ When SYNC is non-nil, match items are returned."
                  extra-args "--" directory
                  (when magit-todos-exclude-globs
                    (--map (concat ":!" it)
-                          magit-todos-exclude-globs))))
+                          magit-todos-exclude-globs))
+                 (unless magit-todos-show-submodule-notes
+                   (--map (list "--glob" (concat "!" it))
+                          (magit-list-module-paths)))))
 
 (magit-todos-defscanner "git diff"
   ;; NOTE: This scanner implements the regexp *searching* in elisp rather than in the
@@ -1343,6 +1353,11 @@ When SYNC is non-nil, match items are returned."
                            (list "-o" "("
                                  (--map (list "-iname" it)
                                         magit-todos-exclude-globs)
+                                 ")" "-prune"))
+                         (unless magit-todos-show-submodule-notes
+                           (list "-o" "("
+                                 (--map (list "-iname" it)
+                                        (magit-list-module-paths))
                                  ")" "-prune")))
                    (list "-o" "-type" "f")
                    ;; NOTE: This uses "grep -P", i.e. "Interpret the pattern as a


### PR DESCRIPTION
Optionally do not search for notes in git submodules.
Closes #104

Example: [document-viewer repo](https://github.com/SufficientlySecure/document-viewer) with `magit-todos-show-submodule-notes` set to `t`:

![2020-10-27_22-58](https://user-images.githubusercontent.com/26824900/97355473-0147ff00-18a8-11eb-888a-a3e0edbe55d9.png)

`magit-todos-show-submodule-notes` set to `nil`:

![2020-10-27_22-57](https://user-images.githubusercontent.com/26824900/97355461-fe4d0e80-18a7-11eb-9d7b-b34c6c93bee2.png)
