### PR TITLE
Fix #95 properly bind keys to magit-status-jump using transient

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/magit-todos
 ;; Version: 1.6-pre
-;; Package-Requires: ((emacs "25.2") (async "1.9.2") (dash "2.13.0") (f "0.17.2") (hl-todo "1.9.0") (magit "2.13.0") (pcre2el "1.8") (s "1.12.0"))
+;; Package-Requires: ((emacs "25.2") (async "1.9.2") (dash "2.13.0") (f "0.17.2") (hl-todo "1.9.0") (magit "2.13.0") (pcre2el "1.8") (s "1.12.0") (transient "0.2.0"))
 ;; Keywords: magit, vc
 
 ;;; Commentary:
@@ -73,6 +73,7 @@
 (require 'f)
 (require 'hl-todo)
 (require 'magit)
+(require 'transient)
 (require 'pcre2el)
 (require 's)
 
@@ -373,18 +374,18 @@ from the \"topic2\" branch, this option could be set to
   :global t
   (if magit-todos-mode
       (progn
-        (pcase (lookup-key magit-status-mode-map "jT")
-          ('nil (define-key magit-status-mode-map "jT" #'magit-todos-jump-to-todos))
-          ('magit-todos-jump-to-todos nil)
-          (_ (message "magit-todos: Not overriding bind of \"jT\" in `magit-status-mode-map'.")))
+        (transient-append-suffix
+          #'magit-status-jump
+          '(0 -1)
+          '[("T" "Todos" magit-todos-jump-to-todos)
+            ("l" "List todos" magit-todos-list)])
         (magit-add-section-hook 'magit-status-sections-hook
                                 #'magit-todos--insert-todos
                                 nil
                                 'append)
         (add-hook 'magit-status-mode-hook #'magit-todos--add-to-status-buffer-kill-hook 'append))
     ;; Disable mode
-    (when (equal (lookup-key magit-status-mode-map "jT") #'magit-todos-jump-to-todos)
-      (define-key magit-status-mode-map "jT" nil))
+    (transient-remove-suffix #'magit-status-jump '(0 -1))
     (remove-hook 'magit-status-sections-hook #'magit-todos--insert-todos)
     (remove-hook 'magit-status-mode-hook #'magit-todos--add-to-status-buffer-kill-hook)))
 


### PR DESCRIPTION
The previous PR to fix this issue has gone stale and was not properly removing
the transient suffix when `magit-todos-mdoe` is turned off. This PR fixes these
issues.