### PR TITLE
Default `magit-todos-exclude-globs` to include .git/

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,6 +138,9 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 *Added*
 +  Option =magit-todos-submodule-list= controls whether to-dos in submodules are displayed (default: off).  (Thanks to [[https://github.com/matsievskiysv][Matsievskiy S.V.]])
 
+*Changed*
++  Option =magit-todos-exclude-globs= now excludes the `.git/` directory by default.  (Thanks to [[https://github.com/Amorymeltzer][Amorymeltzer]].)
+
 *Internal*
 +  Define jumper keys using a Transient suffix.
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -323,7 +323,7 @@ used."
                  (const :tag "After unstaged files" unstaged)
                  (symbol :tag "After selected section")))
 
-(defcustom magit-todos-exclude-globs nil
+(defcustom magit-todos-exclude-globs '(".git/")
   "Glob patterns to exclude from searches."
   :type '(repeat string))
 


### PR DESCRIPTION
There shouldn't ever be a need to include the git-dir.  It's often levels deep and can include a lot of items, none of which are relevant but some of which — `rr-cache/` in particular — can give false positives.

----

Happy to be wrong/discuss this, but it seemed straightforward so figured I'd open a PR rather than issue.  Setting `magit-todos-depth` can obviously hide this as well.