### PR TITLE
FIX: Inconsistent behavior between hl-todos and magit-todos

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -1188,7 +1188,7 @@ When SYNC is non-nil, match items are returned."
                                              (1+ space)
                                              (group (1+ not-newline)))
                                         ;; Non-Org
-                                        (seq (or bol (1+ blank))
+                                        (seq (or bol (1+ (not alphanumeric)))
                                              (group (or ,@keywords))
                                              (regexp ,magit-todos-keyword-suffix)
                                              (optional (1+ blank)


### PR DESCRIPTION
This patch addressses [Magit-todos Issue 124](https://github.com/alphapapa/magit-todos/issues/124).

Magit-todos has inconsistent behavior with hl-todos.  If a keyword doesn't
start with a whitespace character (using the elisp-regexp symbol `blank`),
hl-todos will find it, but magit-todos will not.

This has consequences for documentation writers who typically leave their
todo tasks in-line with the documentation, using the "to come" convention
of `[TK: Do something here]`. Since the keyword "TK" does not have a leading
space, hl-todos will find it, but magit-todos will not.

This patch replaces the requirement that the keyword be proceeded with a
whitespace character with a more general case of `(not alphanumeric)`. This
creates behavior that matches hl-todos more closely.  This change is only
applied to the "non-org" branch of the macro.