### PR TITLE
Fallback for magit--tramp-asserts to make magit-todos-list work with magit master branch

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -466,7 +466,11 @@ With prefix, prompt for repository."
 ;;;###autoload
 (defun magit-todos-list-internal (directory)
   "Open buffer showing to-do list of repository at DIRECTORY."
-  (magit--tramp-asserts directory)
+  (if (fboundp 'magit--tramp-asserts)
+      (magit--tramp-asserts directory)
+    (when (file-remote-p directory)
+      (magit-git-version-assert)))
+
   (let ((default-directory directory))
     (magit-setup-buffer #'magit-todos-list-mode)))
 


### PR DESCRIPTION
magit--tramp-asserts was removed in https://github.com/magit/magit/commit/8394f0d4 and replaced with magit-git-version-assert.  This falls back to the new logic used by magit: https://github.com/magit/magit/commit/8394f0d4#diff-da87988cc81d9c838a54038a8d23abf3b26f7a40f9da560ad31ad63dc004adbeR421