### PR TITLE
Fix Error with regexp Stack Overflows

### DIFF
--- a/README.org
+++ b/README.org
@@ -140,6 +140,9 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 +  Option =magit-todos-exclude-globs= now excludes the `.git/` directory by default.  (Thanks to [[https://github.com/Amorymeltzer][Amorymeltzer]].)
 +  Library ~org~ is no longer loaded automatically, but only when needed.  (This can reduce load time, especially if the user's Org configuration is complex.)  ([[https://github.com/alphapapa/magit-todos/issues/120][#120]].  Thanks to [[https://github.com/meedstrom][Martin Edström]] and [[https://github.com/jsigman][Johnny Sigman]] for suggesting.)
 
+*Fixed*
++ Regexp overflow error for very long lines.  ([[https://github.com/alphapapa/magit-todos/pull/131][#131]].  Thanks to [[https://github.com/LaurenceWarne][Laurence Warne]].)
+
 *Internal*
 +  Define jumper keys using a Transient suffix.
 +  Use new git-testing function in Magit for remote directories.  ([[https://github.com/alphapapa/magit-todos/pull/126][#126]].  Thanks to [[https://github.com/maxhollmann][Max Hollmann]].)

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -556,7 +556,8 @@ Match items are a list of `magit-todos-item' found in PROCESS's buffer for RESUL
                       ;; FIXME: This may raise multiple warnings per file.
                       (error (if (string= "Stack overflow in regexp matcher" (error-message-string err))
                                  (let ((filename (buffer-substring (point) (1- (re-search-forward ":")))))
-                                   (display-warning 'magit-todos (concat "File has lines too long for Emacs to search.  Consider excluding it from scans: " filename)))
+                                   (display-warning 'magit-todos (concat "File has lines too long for Emacs to search.  Consider excluding it from scans: " filename))
+                                   nil)
                                (signal (car err) (cdr err)))))
           (push it items))
         (forward-line 1)))


### PR DESCRIPTION
Hi, I kept getting `error in process sentinel: Wrong type argument: magit-todos-item, t` whenever I opened the magit status buffer for a file in the https://github.com/github/linguist repo.

I found that when a stack overflow occurred during regexp matching `(display-warning 'magit-todos (concat "File has lines too long for Emacs to search.  Consider excluding it from scans: " filename))` was returning `t`, which was causing the enclosing `--when-let` to treat the `t` as a todo item and add it to the list of todo items, which caused the above error when writing it to a buffer.

AFAICS the doc for `display-warning` doesn't say anything about its return value  (`(display-warning 'foo "foo")` returns `t` :shrug:), so for surety this PR just adds `nil` to the next line.

I can reproduce it with minimal config using the following:
1. `git clone https://github.com/github/linguist` (though I think any repo with an uber line will do, e.g. this file is the culprit in that repo: https://github.com/github/linguist/blob/master/test/fixtures/Data/bootstrap.css.map)
2. `./makem.sh interactive` 
3. `magit-todos-mode`, `magit`
4. Open any file in the repo, wait a bit

Thanks!