### PR TITLE
Fix "repetition operator mission error" on windows

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -1198,7 +1198,7 @@ When SYNC is non-nil, match items are returned."
                                              (regexp ,magit-todos-keyword-suffix)
                                              (optional (1+ blank)
                                                        (group (1+ not-newline)))))))
-                (search-regexp-pcre (rxt-elisp-to-pcre search-regexp-elisp))
+                (search-regexp-pcre (s-replace "\\" "\\\\" (rxt-elisp-to-pcre search-regexp-elisp)))
                 (results-regexp (or ,results-regexp
                                     (rx-to-string
                                      `(seq bol


### PR DESCRIPTION
I had issues similar to #29 where I was getting the following error:
```sh
regex parse error:
    ^(*+)[[:blank:]]+(DONT|F(?:AIL|IXME)|H(?:ACK|OLD)|KLUDGE|NEXT|OKAY|PROG|T(?:EMP|HEM|ODO)|XXXX*)[[:space:]]+(.+)|(?:^|[[:blank:]]+)(DONT|F(?:AIL|IXME)|H(?:ACK|OLD)|KLUDGE|NEXT|OKAY|PROG|T(?:EMP|HEM|ODO)|XXXX*)(?:([^)]+))?:(?:[[:blank:]]+(.+))?
      ^
error: repetition operator missing expression
```

It seemed when the processed args for the command is processed `start-file-process` in `magit-todos--async-start-process`, the `\` characters in the regex get's dropped. This PR is simply a fix for that. 

Would need more testing in other operating systems to make sure it works across all use-cases.