### PR TITLE
Disable automatic scans in remote repositories, add option to re-renable

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,7 +141,9 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 :CUSTOM_ID: TRAMP
 :END:
 
-To-dos are not automatically scanned in remote repositories accessed via TRAMP, unless ~magit-todos-update-remote~ is set.  Note that if TRAMP can't find the scanner configured in =magit-todos-scanner=, you may need to use directory-local variables to either add the correct path to =tramp-remote-path= or choose a different scanner.
+Remote repositories (i.e. ones accessed via TRAMP) are not automatically scanned for to-dos unless option ~magit-todos-update-remote~ is enabled.  Otherwise, a scan may be manually initiated with the command ~magit-todos-update~.
+
+Note that if TRAMP can't find the scanner configured in option ~magit-todos-scanner~, you may need to use directory-local variables to either add the correct path to variable ~tramp-remote-path~ or choose a different scanner.
 
 * Changelog
 :PROPERTIES:
@@ -152,9 +154,10 @@ To-dos are not automatically scanned in remote repositories accessed via TRAMP, 
 
 *Additions*
 + Branch-specific TODOs are also cached (to avoid rescanning when automatic updates are disabled.  This can improve performance in large repos).
++ Option ~magit-todos-upate-remote~ allows automatic scanning in remote repositories.  ([[https://github.com/alphapapa/magit-todos/pull/157][#157]].  Thanks to [[https://github.com/projectgus][Angus Gratton]].)
 
 *Changes*
-+ To-dos are not automatically scanned in remote repositories accessed via TRAMP, unless new option ~magit-todos-update-remote~ is set.  ([[https://github.com/alphapapa/magit-todos/pull/157][#157]].  Thanks to [[https://github.com/projectgus][Angus Gratton]].)
++ Remote repositories are no longer automatically scanned (see new option ~magit-todos-update-remote~).
 + Option ~magit-todos-keyword-suffix~ defaults to allowing suffixes to be enclosed by parentheses or brackets (rather than just parentheses).
 + Minor improvements to warnings about files containing very long lines: display as messages instead of warnings, and signal errors from outside the process sentinel.
 

--- a/README.org
+++ b/README.org
@@ -141,7 +141,7 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 :CUSTOM_ID: TRAMP
 :END:
 
-=magit-todos= attempts to work in remote repositories accessed via TRAMP.  Note that if TRAMP can't find the scanner configured in =magit-todos-scanner=, you may need to use directory-local variables to either add the correct path to =tramp-remote-path= or choose a different scanner.
+To-dos are not automatically scanned in remote repositories accessed via TRAMP, unless ~magit-todos-update-remote~ is set.  Note that if TRAMP can't find the scanner configured in =magit-todos-scanner=, you may need to use directory-local variables to either add the correct path to =tramp-remote-path= or choose a different scanner.
 
 * Changelog
 :PROPERTIES:
@@ -154,6 +154,7 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 + Branch-specific TODOs are also cached (to avoid rescanning when automatic updates are disabled.  This can improve performance in large repos).
 
 *Changes*
++ To-dos are not automatically scanned in remote repositories accessed via TRAMP, unless new option ~magit-todos-update-remote~ is set.  ([[https://github.com/alphapapa/magit-todos/pull/157][#157]].  Thanks to [[https://github.com/projectgus][Angus Gratton]].)
 + Option ~magit-todos-keyword-suffix~ defaults to allowing suffixes to be enclosed by parentheses or brackets (rather than just parentheses).
 + Minor improvements to warnings about files containing very long lines: display as messages instead of warnings, and signal errors from outside the process sentinel.
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -208,7 +208,7 @@ items."
                  (const :tag "Manually" nil)))
 
 (defcustom magit-todos-update-remote nil
- "Automatically scan in remote repositories.
+  "Automatically scan in remote repositories.
 If nil, remote repos are only scanned when a manual scan is
 initiated (see command `magit-todos-update').  Remote repos
 include ones accessed via TRAMP (i.e. any path for which
@@ -720,8 +720,8 @@ Assumes current buffer is ITEM's buffer."
 This function should be called from inside a ‘magit-status’ buffer."
   (declare (indent defun))
   (when (or magit-todos-update-remote
-          magit-todos-updating
-          (not (file-remote-p default-directory)))
+            magit-todos-updating
+            (not (file-remote-p default-directory)))
     ;; Skip automatic scans of remote buffers if magit-todos-update-remote is unset.
     (when magit-todos-active-scan
       ;; Avoid running multiple scans for a single magit-status buffer.
@@ -733,28 +733,28 @@ This function should be called from inside a ‘magit-status’ buffer."
       (setq magit-todos-active-scan nil))
     (pcase magit-todos-update
       ((or 't                           ; Automatic
-         ;; Manual and updating now
-         (and 'nil (guard magit-todos-updating))
-         ;; Caching and cache expired
-         (and (pred integerp) (guard (or magit-todos-updating ; Forced update
-                                       (>= (float-time
-                                             (time-subtract (current-time)
-                                               magit-todos-last-update-time))
-                                         magit-todos-update)
-                                       (null magit-todos-last-update-time)))))
-        ;; Scan and insert.
-        ;; HACK: I don't like setting a special var here, because it seems like lexically binding a
-        ;; special var should follow down the chain, but it isn't working, so we'll do this.
-        (setq magit-todos-updating t)
-        (setq magit-todos-active-scan (funcall magit-todos-scanner
-                                        :callback #'magit-todos--insert-items
-                                        :magit-status-buffer (current-buffer)
-                                        :directory default-directory
-                                        :depth magit-todos-depth))
-        (magit-todos--maybe-insert-branch-todos 'rescan))
+           ;; Manual and updating now
+           (and 'nil (guard magit-todos-updating))
+           ;; Caching and cache expired
+           (and (pred integerp) (guard (or magit-todos-updating ; Forced update
+                                           (>= (float-time
+                                                (time-subtract (current-time)
+                                                               magit-todos-last-update-time))
+                                               magit-todos-update)
+                                           (null magit-todos-last-update-time)))))
+       ;; Scan and insert.
+       ;; HACK: I don't like setting a special var here, because it seems like lexically binding a
+       ;; special var should follow down the chain, but it isn't working, so we'll do this.
+       (setq magit-todos-updating t)
+       (setq magit-todos-active-scan (funcall magit-todos-scanner
+                                              :callback #'magit-todos--insert-items
+                                              :magit-status-buffer (current-buffer)
+                                              :directory default-directory
+                                              :depth magit-todos-depth))
+       (magit-todos--maybe-insert-branch-todos 'rescan))
       (_ ; Caching and cache not expired, or not automatic and not manually updating now
-        (magit-todos--insert-items (current-buffer) magit-todos-item-cache)
-        (magit-todos--maybe-insert-branch-todos 'cached)))))
+       (magit-todos--insert-items (current-buffer) magit-todos-item-cache)
+       (magit-todos--maybe-insert-branch-todos 'cached)))))
 
 (defun magit-todos--maybe-insert-branch-todos (&optional type)
   "Insert branch todos when appropriate.

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -722,7 +722,6 @@ This function should be called from inside a ‘magit-status’ buffer."
   (when (or magit-todos-update-remote
             magit-todos-updating
             (not (file-remote-p default-directory)))
-    ;; Skip automatic scans of remote buffers if magit-todos-update-remote is unset.
     (when magit-todos-active-scan
       ;; Avoid running multiple scans for a single magit-status buffer.
       (let ((buffer (process-buffer magit-todos-active-scan)))


### PR DESCRIPTION
New option `magit-todos-update-remote` controls whether todos are automatically updated in remote repos (accessed via TRAMP). Defaults to disabled.

New option was suggested in https://github.com/alphapapa/magit-todos/issues/132 (although not a fix for that issue), and is disabled by default as suggested in https://github.com/alphapapa/magit-todos/pull/157#issuecomment-1820310367.

Thanks for developing magit-todos, it's very handy! :grin: 