### PR TITLE
Add safeguard around git diff scan

### DIFF
--- a/README.org
+++ b/README.org
@@ -161,6 +161,10 @@ Note that if TRAMP can't find the scanner configured in option ~magit-todos-scan
 :TOC: :ignore descendants
 :END:
 
+** 1.9-pre
+
+Nothing new yet.
+
 ** 1.8
 
 *Additions*

--- a/README.org
+++ b/README.org
@@ -163,7 +163,9 @@ Note that if TRAMP can't find the scanner configured in option ~magit-todos-scan
 
 ** 1.9-pre
 
-Nothing new yet.
+*Fixes*
+
++ Don't run simultaneous branch-diff scans on the same repo. ([[https://github.com/alphapapa/magit-todos/issues/145][#145]].  Thanks to [[https://github.com/mpaulmier][Matthias Paulmier]].) 
 
 ** 1.8
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/magit-todos
-;; Version: 1.8
+;; Version: 1.9-pre
 ;; Package-Requires: ((emacs "26.1") (async "1.9.2") (dash "2.13.0") (f "0.17.2") (hl-todo "1.9.0") (magit "2.13.0") (pcre2el "1.8") (s "1.12.0") (transient "0.2.0"))
 ;; Keywords: magit, vc
 


### PR DESCRIPTION
This is to prevent the scan to be run multiple times and show more than once in Magit's buffer

Fixes #145 && #127 (reopening of #154)