### PR TITLE
Do not set parent keymap of magit-todos-section-map

### DIFF
--- a/README.org
+++ b/README.org
@@ -143,7 +143,8 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 
 ** 1.7.2-pre
 
-Nothing new yet.
+*Fixes*
++ Don't set parent keymap.  ([[https://github.com/alphapapa/magit-todos/issues/173][#173]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 
 ** 1.7.1
 

--- a/README.org
+++ b/README.org
@@ -141,6 +141,10 @@ Helm and Ivy are also supported.  Note that the =helm= and =ivy= packages are no
 :TOC: :ignore descendants
 :END:
 
+** 1.7.2-pre
+
+Nothing new yet.
+
 ** 1.7.1
 
 *Fixes*

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -119,7 +119,6 @@ Used to avoid running multiple simultaneous scans for a
 
 (defvar magit-todos-section-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map magit-status-mode-map)
     (define-key map "b" #'magit-todos-branch-list-toggle)
     (define-key map "B" #'magit-todos-branch-list-set-commit)
     (define-key map [remap magit-visit-thing] #'magit-todos-list)

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/magit-todos
-;; Version: 1.7.1
+;; Version: 1.7.2-pre
 ;; Package-Requires: ((emacs "26.1") (async "1.9.2") (dash "2.13.0") (f "0.17.2") (hl-todo "1.9.0") (magit "2.13.0") (pcre2el "1.8") (s "1.12.0") (transient "0.2.0"))
 ;; Keywords: magit, vc
 


### PR DESCRIPTION
This is not necessary to make the regular magit-status keys work in
the TODOs section.

In fact, it causes a bug when used with evil-collection, which uses x
instead of k for delete (so that k can move the cursor up one line).
Setting the parent keymap unnecessarily confuses evil-collection and
causes k to attempt to delete the "thing" at point instead of
scrolling up.