### PR TITLE
Disable external diff tools when calling git diff

### DIFF
--- a/README.org
+++ b/README.org
@@ -164,6 +164,9 @@ Note that if TRAMP can't find the scanner configured in option ~magit-todos-scan
 *Removals*
 + Obsolete option ~magit-todos-insert-at~, replaced by option ~magit-todos-insert-after~.  (Scheduled for removal since v1.6.)
 
+*Fixes*
++ Disable external diff drivers when calling ~git diff~.  ([[https://github.com/alphapapa/magit-todos/pull/174][#174]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].) 
+
 ** 1.7.2
 
 *Fixes*

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -1419,7 +1419,7 @@ When SYNC is non-nil, match items are returned."
                                        shell-command-to-string
                                        string-trim)))
                (unless (string-empty-p merge-base-ref)
-                 (list "git" "--no-pager" "diff" "--no-color" "-U0" merge-base-ref))))
+                 (list "git" "--no-pager" "diff" "--no-ext-diff" "--no-color" "-U0" merge-base-ref))))
   :callback 'magit-todos--git-diff-callback)
 
 (magit-todos-defscanner "find|grep"


### PR DESCRIPTION
External diffing tools are likely to produce output in a different
format than git diff, or output that is not intended for programmatic
consumption.