### PR TITLE
Change: (magit-todos-exclude-globs) Mark as safe

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -359,7 +359,8 @@ used."
 
 (defcustom magit-todos-exclude-globs '(".git/")
   "Glob patterns to exclude from searches."
-  :type '(repeat string))
+  :type '(repeat string)
+  :safe #'list-of-strings-p)
 
 (defcustom magit-todos-branch-list 'branch
   "Show branch diff to-do list.


### PR DESCRIPTION
In one of my projects, I have a `deprecated/` folder with files that had TODOs in them before I deprecated them.  I want to the leave the TODOs as-is, but I don't want to be reminded about them in the Magit status buffer.

This change allows me to set `magit-todos-exclude-globs` in `.dir-locals.el` without being warned.