### PR TITLE
Avoid saving default magit-todos-insert-after to custom-file

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -348,6 +348,7 @@ used."
                  (const :tag "After untracked files" untracked)
                  (const :tag "After unstaged files" unstaged)
                  (symbol :tag "After selected section"))
+  :initialize 'custom-initialize-changed
   :set (lambda (option value)
          ;; For convenience, we set the new option with the appropriate value (but,
          ;; of course, this won't work for users who set it directly with `setq'.)


### PR DESCRIPTION
Using custom-initialize-changed causes the :set function to only be
used if the variable was already set (e.g., customized by the user),
but if defcustom is just defining the default value, it will not call
the setter and cause magit-todos-insert-after to be saved to
custom-file.