### PR TITLE
Don't use obsolete generalized variable

### DIFF
--- a/magit-todos.el
+++ b/magit-todos.el
@@ -670,7 +670,8 @@ filenames to be excluded."
                       (push item items)))
                   (cl-incf line-number))))))
         (let ((magit-todos-section-heading heading))
-          (setf (buffer-local-value 'magit-todos-branch-item-cache magit-status-buffer) items)
+          (with-current-buffer magit-status-buffer
+            (setq-local magit-todos-branch-item-cache items))
           (magit-todos--insert-items magit-status-buffer items :branch-p t))))))
 
 (defun magit-todos--delete-section (condition)


### PR DESCRIPTION
Emacs 29.1 made many generalized variables obsolete, including `buffer-local-value`.