### PR TITLE
Fix: Make git-grep scanner's test for PCRE2 support more robust

### DIFF
--- a/README.org
+++ b/README.org
@@ -165,7 +165,10 @@ Note that if TRAMP can't find the scanner configured in option ~magit-todos-scan
 + Obsolete option ~magit-todos-insert-at~, replaced by option ~magit-todos-insert-after~.  (Scheduled for removal since v1.6.)
 
 *Fixes*
-+ Disable external diff drivers when calling ~git diff~.  ([[https://github.com/alphapapa/magit-todos/pull/174][#174]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].) 
++ Disable external diff drivers when calling ~git diff~.  ([[https://github.com/alphapapa/magit-todos/pull/174][#174]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
+
+*Compatibility*
++ Update test for ~git-grep~ scanner compatibility for newer versions of Git.  (See [[https://github.com/alphapapa/magit-todos/issues/186][#186]].  Thanks to [[https://github.com/KarlJoad][Karl Hallsby]].)
 
 ** 1.7.2
 

--- a/magit-todos.el
+++ b/magit-todos.el
@@ -1389,15 +1389,12 @@ When SYNC is non-nil, match items are returned."
                  extra-args search-regexp-pcre directory))
 
 (magit-todos-defscanner "git grep"
-  ;; This test is evaluated at Emacs start! To allow the git grep :test to work
-  ;; regardless of whether or not Emacs was started inside of a Git repository,
-  ;; we use --no-index and - (STDIN). --no-index makes "git grep" behave like
-  ;; "grep -r". We then use - as the input (STDIN) so that we do not rely on
-  ;; specifying any actual files.
-  :test (not (string-match "fatal" (shell-command-to-string "git grep --no-index --quiet --perl-regexp '\\d' -- -")))
-  ;; git-grep exits this test with 128 if PCRE is not supported. We also allow
-  ;; exit code 1, because it means a successful grep run (--perl-regexp IS
-  ;; supported), but there are no matches.
+  ;; To allow git-grep to work regardless of whether `default-directory'
+  ;; is in a Git repository, we use "--no-index" (which acts like "grep
+  ;; -r") and "-" (STDIN, so we needn't specify files).  git-grep exits
+  ;; this test with 128 if PCRE is not supported.  We also allow exit
+  ;; code 1, because it means a successful grep run (i.e. "--perl-regexp"
+  ;; is supported) without matches.
   :test (>= 1 (call-process-shell-command "git grep --no-index --quiet --perl-regexp '\\d' -- -"))
   :allow-exit-codes (0 1)
   :command (list "git" "--no-pager" "grep"


### PR DESCRIPTION
**Both** tests for git-grep PCRE2 support that I suggested in #186 are present. I do not know which you would prefer to keep @alphapapa. Feel free to change this commit as you need.